### PR TITLE
docs(ci): clarify CI inline generator; add README local docs section

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,8 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  # Note: CI generates Swagger UI inline. The PowerShell helper at
+  # scripts/generate-api-docs.ps1 is for local use only and is not used by CI.
   publish-api-docs:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     needs: [backend-tests, e2e-frontend]

--- a/README.md
+++ b/README.md
@@ -231,6 +231,19 @@ Set these in GitHub → Settings → Secrets and variables → Actions:
 
 Prisma versioning: CI currently pins `prisma@5.22.0`. Ignore local upgrade prompts to v6 until we coordinate a repo-wide upgrade.
 
+## Local docs generation
+
+If you want to preview the API docs locally without GitHub Actions:
+
+```powershell
+# From repo root (Windows PowerShell)
+scripts/generate-api-docs.ps1 -SourceSpec "docs/openapi.yaml" -OutDir "docs/site"
+```
+
+This copies `docs/openapi.yaml` to `docs/site/openapi.yaml` and creates `docs/site/index.html` with Swagger UI. Then open `docs/site/index.html` in your browser.
+
+Note: CI uses an inline generator in `publish-api-docs` within `.github/workflows/ci.yml` and does not call this script. The script is a convenience for local development only.
+
 ## Health Endpoints
 
 The backend exposes two health endpoints for convenience:


### PR DESCRIPTION
- CI continues to publish Swagger UI with the inline generator (no functional change).
- Added a comment in ci.yml clarifying that scripts/generate-api-docs.ps1 is for local use only.
- Updated README with a “Local docs generation” section showing how to build docs/site with PowerShell.

Docs remain published via Pages:
https://ahmad9bh.github.io/Celebrate/
